### PR TITLE
 - fix dxcc entity identification (prefer dxcc in the input ADIF file…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>uk.m0nom</groupId>
   <artifactId>adif-processor</artifactId>
-  <version>1.3.8</version>
+  <version>1.3.9</version>
 
   <name>ADIF Processor</name>
   <url>https://github.com/urbancamo/adif-processor</url>

--- a/src/main/java/uk/m0nom/adifproc/adif3/transform/CommentParsingAdifRecordTransformer.java
+++ b/src/main/java/uk/m0nom/adifproc/adif3/transform/CommentParsingAdifRecordTransformer.java
@@ -362,8 +362,8 @@ public class CommentParsingAdifRecordTransformer implements Adif3RecordTransform
         // Set DXCC Entities
         ZonedDateTime date = qso.getRecord().getQsoDate();
         if (date != null) {
-            qso.getFrom().setDxccEntity(control.getDxccEntities().findDxccEntityFromCallsign(qso.getFrom().getCallsign(), qso.getRecord().getQsoDate()));
-            qso.getTo().setDxccEntity(control.getDxccEntities().findDxccEntityFromCallsign(qso.getTo().getCallsign(), qso.getRecord().getQsoDate()));
+            control.getDxccEntities().setFromDxccEntity(qso, control);
+            control.getDxccEntities().setToDxccEntity(qso, control);
         } else {
             results.addWarning(String.format("Record %d with station %s has no date", index, qso.getTo().getCallsign()));
         }

--- a/src/main/java/uk/m0nom/adifproc/dxcc/DxccPermutations.java
+++ b/src/main/java/uk/m0nom/adifproc/dxcc/DxccPermutations.java
@@ -1,7 +1,6 @@
 package uk.m0nom.adifproc.dxcc;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,7 +16,7 @@ public final class DxccPermutations {
             i--;
         }
         int suffixStart = i+1;
-        String suffix = begin.substring(suffixStart, begin.length());
+        String suffix = begin.substring(suffixStart);
 
         // String suffix off begin and end and generate variants
         List<String> variants = generateInternal(begin.substring(0, suffixStart), end.substring(0, suffixStart));

--- a/src/test/java/uk/m0nom/adifproc/adif3/PreferAdifDxccEntityOverCalculatedDxccEntityFromCallsignTest.java
+++ b/src/test/java/uk/m0nom/adifproc/adif3/PreferAdifDxccEntityOverCalculatedDxccEntityFromCallsignTest.java
@@ -1,0 +1,88 @@
+package uk.m0nom.adifproc.adif3;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.marsik.ham.adif.Adif3;
+import org.marsik.ham.adif.Adif3Record;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.m0nom.adifproc.FileProcessorApplicationConfig;
+import uk.m0nom.adifproc.activity.ActivityDatabaseService;
+import uk.m0nom.adifproc.adif3.contacts.Qso;
+import uk.m0nom.adifproc.adif3.contacts.Station;
+import uk.m0nom.adifproc.adif3.io.Adif3FileReader;
+import uk.m0nom.adifproc.adif3.io.Adif3FileWriter;
+import uk.m0nom.adifproc.adif3.print.Adif3PrintFormatter;
+import uk.m0nom.adifproc.dxcc.DxccEntities;
+import uk.m0nom.adifproc.dxcc.DxccJsonReader;
+import uk.m0nom.adifproc.dxcc.JsonDxccEntities;
+import uk.m0nom.adifproc.kml.KmlWriter;
+import uk.m0nom.adifproc.qrz.CachingQrzXmlService;
+import uk.m0nom.adifproc.adif3.control.TransformControl;
+import java.text.ParseException;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = FileProcessorApplicationConfig.class)
+public class PreferAdifDxccEntityOverCalculatedDxccEntityFromCallsignTest {
+    @Autowired
+    Adif3Transformer transformer;
+
+    @Autowired
+    Adif3FileReader reader;
+
+    @Autowired
+    Adif3FileWriter writer;
+
+    @Autowired
+    ActivityDatabaseService summits;
+
+    @Autowired
+    Adif3PrintFormatter formatter;
+
+    @Autowired
+    KmlWriter kmlWriter;
+
+    @Autowired
+    CachingQrzXmlService qrzXmlService;
+
+    TransformControl transformControl;
+
+    @Test
+    public void testCountryOverDxcc() {
+        try {
+            transformControl = new TransformControl();
+            JsonDxccEntities jsonDxccEntities = new DxccJsonReader().read();
+            DxccEntities dxccEntities = new DxccEntities();
+            try {
+                dxccEntities.setup(jsonDxccEntities);
+            } catch (ParseException p) {
+                Assertions.fail(p);
+            }
+
+            transformControl.setDxccEntities(dxccEntities);
+            Adif3 input = reader.read("./target/test-classes/adif/LU7HF.adi", "windows-1251", false);
+            assert input != null;
+            assert input.getRecords().size() == 1;
+            Adif3Record record = input.getRecords().get(0);
+            assert record.getCall().equals("LU7HF");
+            assert record.getCountry().equals("Argentina");
+            assert record.getDxcc().equals(100);
+
+            Qso qso = new Qso(record, 0);
+            Station from = new Station(record.getStationCallsign(), qso);
+            Station to = new Station(record.getStationCallsign(), qso);
+            to.setDxccEntity(dxccEntities.getDxccEntity(100));
+
+            qso.setTo(to);
+            qso.setFrom(from);
+
+            dxccEntities.setToDxccEntity(qso, transformControl);
+            assert(qso.getTo().getDxccEntity().getEntityCode() == 100);
+
+        } catch (Exception e) {
+            Assertions.fail("testApp() threw exception while setting up the test. ", e);
+        }
+    }
+}

--- a/src/test/java/uk/m0nom/adifproc/adif3/transform/comment/FieldParserCommentTransformerTest.java
+++ b/src/test/java/uk/m0nom/adifproc/adif3/transform/comment/FieldParserCommentTransformerTest.java
@@ -1,4 +1,0 @@
-package uk.m0nom.adifproc.adif3.transform.comment;
-
-public class FieldParserCommentTransformerTest {
-}

--- a/src/test/java/uk/m0nom/adifproc/qrz/QrzXmlServiceIntegrationTest.java
+++ b/src/test/java/uk/m0nom/adifproc/qrz/QrzXmlServiceIntegrationTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test the QrzXmlService is able to look up data on a callsign
  * NOTE: you will need to plug in your username and password for this to work correctly
- * (which is why be default this test is ignored)
+ * (which is why the default this test is ignored)
  */
 public class QrzXmlServiceIntegrationTest {
     private final static String USERNAME = "";

--- a/src/test/resources/adif/LU7HF.adi
+++ b/src/test/resources/adif/LU7HF.adi
@@ -1,0 +1,53 @@
+### QLog ADIF Export
+<ADIF_VER:5>3.1.4
+<PROGRAMID:4>QLog
+<PROGRAMVERSION:6>0.34.0
+<CREATED_TIMESTAMP:15>20240515 003039
+<EOH>
+
+<call:5>LU7HF
+<rst_sent:3>599
+<rst_rcvd:3>599
+<freq:6:N>24.895
+<band:3>12m
+<mode:2>CW
+<name:15>MARCELO GABRIEL
+<qth:23>SAN FRANCISCO - CORDOBA
+<gridsquare:6>FF88XS
+<dxcc:3>100
+<country:9>Argentina
+<cont:2>SA
+<cqz:2>13
+<ituz:2>14
+<pfx:3>LU7
+<state:2>Se
+<qsl_rcvd:1>N
+<qsl_sent:1>Q
+<lotw_qsl_rcvd:1>N
+<lotw_qsl_sent:1>Y
+<lotw_qslsdate:8>20240510
+<tx_pwr:3>100
+<a_index:1>7
+<band_rx:3>12m
+<distance:17>7002.559901983147
+<eqsl_qslsdate:8>20240511
+<eqsl_qsl_rcvd:1>N
+<eqsl_qsl_sent:1>Y
+<freq_rx:6>24.895
+<k_index:1>2
+<my_antenna:7>doublet
+<my_city:11>Bushnell FL
+<my_country:13>United States
+<my_cq_zone:1>5
+<my_dxcc:3>291
+<my_gridsquare:4>EL88
+<my_itu_zone:1>8
+<my_name:4>Dave
+<my_rig:5>FT710
+<sfi:3>233
+<station_callsign:4>KZ1O
+<qso_date:8:D>20240509
+<time_on:6:T>213531
+<qso_date_off:8:D>20240509
+<time_off:6:T>213639
+<eor>


### PR DESCRIPTION
… as it is more reliable than calculating it from the callsign)